### PR TITLE
add html support

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -39,7 +39,7 @@ class File {
       }
     }
 
-    if (this.isMarkdown) {
+    if (this.isMarkdown || this.isHTML) {
       try {
         const data = requireMarkdown(fs.readFileSync(this.filename, 'utf8'))
         delete data.orig
@@ -58,6 +58,10 @@ class File {
 
   get isYAML () {
     return this.filename.match(/\.(yml|yaml)$/i)
+  }
+
+  get isHTML () {
+    return this.filename.match(/\.(htm|html)$/i)
   }
 
   get isMarkdown () {

--- a/readme.md
+++ b/readme.md
@@ -59,8 +59,8 @@ Here's an example that ignores certain paths using chokidar's
 ```js
 const options = {
   ignored: [
-    '**/*.md', 
-    '**/*.json'
+    '**/*.md',
+    '**/*.json',
     (filename) => filename.includes('.html')
   ]
 }

--- a/test/fixtures/html_with_frontmatter.html
+++ b/test/fixtures/html_with_frontmatter.html
@@ -1,0 +1,39 @@
+---
+title: Blog
+permalink: /blog/
+layout: default
+excerpt: All the latest news from the Electron team and community.
+---
+
+
+<div class='subtron'>
+  <div class='container-narrow'>
+    <h1>Electron Blog</h1>
+    <p class="lead mb-3">
+      All the latest news from the Electron team and community.
+      Subscribe to the <a href="{{ site.baseurl }}/feed.xml"> RSS feed</a>.
+    </p>
+  </div>
+</div>
+
+<section class='page-section'>
+  <div class='container-narrow'>
+    <ul class="blog-index">
+      {% for post in site.posts %}
+        <li class="mb-4 mb-md-6 mb-lg-8">
+          <h2>
+            <a class="blog-index-link mr-2" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+
+            <div class="who-when mt-1">
+              <span class="octicon octicon-calendar pr-2"></span><time class="blog-index-time">{{ post.date | date: '%B %d, %Y' }}</time>
+              <a href="https://github.com/{{ post.author }}" class="author-link ml-3"><img src="https://github.com/{{ post.author }}.png?size=36" alt="{{ post.author }}" class="avatar mr-2">{{ post.author }}</a>
+            </div>
+          </h2>
+
+          {{ post.excerpt }}
+          <p><a href="{{ post.url | prepend: site.baseurl }}">Read more <span class="octicon octicon-arrow-small-right"></span></a></p>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>

--- a/test/fixtures/html_without_frontmatter.html
+++ b/test/fixtures/html_without_frontmatter.html
@@ -1,0 +1,31 @@
+<div class='subtron'>
+  <div class='container-narrow'>
+    <h1>Electron Blog</h1>
+    <p class="lead mb-3">
+      All the latest news from the Electron team and community.
+      Subscribe to the <a href="{{ site.baseurl }}/feed.xml"> RSS feed</a>.
+    </p>
+  </div>
+</div>
+
+<section class='page-section'>
+  <div class='container-narrow'>
+    <ul class="blog-index">
+      {% for post in site.posts %}
+        <li class="mb-4 mb-md-6 mb-lg-8">
+          <h2>
+            <a class="blog-index-link mr-2" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+
+            <div class="who-when mt-1">
+              <span class="octicon octicon-calendar pr-2"></span><time class="blog-index-time">{{ post.date | date: '%B %d, %Y' }}</time>
+              <a href="https://github.com/{{ post.author }}" class="author-link ml-3"><img src="https://github.com/{{ post.author }}.png?size=36" alt="{{ post.author }}" class="avatar mr-2">{{ post.author }}</a>
+            </div>
+          </h2>
+
+          {{ post.excerpt }}
+          <p><a href="{{ post.url | prepend: site.baseurl }}">Read more <span class="octicon octicon-arrow-small-right"></span></a></p>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>

--- a/test/index.js
+++ b/test/index.js
@@ -28,18 +28,6 @@ describe('tree-hugger', function () {
     expect(data.meetups).to.be.an('array')
   })
 
-  it('parses Markdown with frontmatter', () => {
-    expect(data.webtorrent).to.be.an('object')
-    expect(data.webtorrent.data.title).to.be.a('string')
-    expect(data.webtorrent.content).to.be.a('string')
-  })
-
-  it('parses Markdown without frontmatter', () => {
-    expect(data.simple_markdown).to.be.an('object')
-    expect(data.simple_markdown.data).to.deep.equal({})
-    expect(data.simple_markdown.content).to.be.a('string')
-  })
-
   it('ignores .DS_Store macOS directories', () => {
     expect(Object.keys(data)).to.not.include('DS_Store')
     expect(Object.keys(data)).to.not.include('.DS_Store')
@@ -56,6 +44,34 @@ describe('tree-hugger', function () {
 
   it('preserves dots in filenames', () => {
     expect(data.featured.apps).to.be.an('array')
+  })
+
+  describe('Markdown', () => {
+    it('parses Markdown with frontmatter', () => {
+      expect(data.webtorrent).to.be.an('object')
+      expect(data.webtorrent.data.title).to.be.a('string')
+      expect(data.webtorrent.content).to.be.a('string')
+    })
+
+    it('parses Markdown without frontmatter', () => {
+      expect(data.simple_markdown).to.be.an('object')
+      expect(data.simple_markdown.data).to.deep.equal({})
+      expect(data.simple_markdown.content).to.be.a('string')
+    })
+  })
+
+  describe('HTML', () => {
+    it('parses HTML with frontmatter', () => {
+      expect(data.html_with_frontmatter).to.be.an('object')
+      expect(data.html_with_frontmatter.data.title).to.eq('Blog')
+      expect(data.html_with_frontmatter.content).to.be.a('string')
+    })
+
+    it('parses HTML without frontmatter', () => {
+      expect(data.html_without_frontmatter).to.be.an('object')
+      expect(data.html_without_frontmatter.data).to.deep.equal({})
+      expect(data.html_without_frontmatter.content).to.be.a('string')
+    })
   })
 
   describe('chokidar options', () => {


### PR DESCRIPTION
Jekyll supports HTML files that contain YML frontmatter.

See https://github.com/electron/electron.atom.io/blob/f2e2ccdfdc342ba4800de2490b04b7271939882c/_pages/blog.html

This adds support for parsing HTML files as data files, whether they contain YML frontmatter or not.