### PR TITLE
Add onFileData middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,11 +17,15 @@ class Crawler extends Emitter {
     // save reference to parent crawler for use in event handlers,
     // where `this` is the chokidar watcher instance
     this.watcher.crawler = this
+
+    // Allow custom processing of files
+    this.watcher.onFileData = options.onFileData
+
     return this
   }
 
   addFile (filename) {
-    const file = new File(filename, this.crawler.paths)
+    const file = new File(filename, this.crawler.paths, this.onFileData)
     if (file.data) {
       set(this.crawler.data, file.key, file.data)
       this.crawler.emit('add', file)

--- a/lib/file.js
+++ b/lib/file.js
@@ -5,7 +5,7 @@ const requireYAML = require('require-yml')
 const requireMarkdown = require('gray-matter')
 
 class File {
-  constructor (filename, crawlPaths) {
+  constructor (filename, crawlPaths, onFileData) {
     this.filename = filename
 
     this.basepath = (typeof crawlPaths === 'string')
@@ -14,6 +14,12 @@ class File {
 
     this.key = this.getKey()
     this.data = this.getData()
+
+    if (typeof onFileData === 'function') {
+      this.data = onFileData(this.data)
+    }
+
+    return this
   }
 
   getKey () {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "chai": "^3.5.0",
     "mocha": "^3.4.2",
     "standard": "^10.0.2",
-    "standard-markdown": "^2.3.0"
+    "standard-markdown": "^4.0.1"
   },
   "scripts": {
     "test": "mocha && standard && standard-markdown"

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,29 @@ becomes
 }
 ```
 
+### `onFileData` Middleware
+
+You can specify a custom function to modify data files as they're added.
+This function accepts a `data` object and should return a modified `data` object.
+
+```js
+const options = {
+  onFileData: function (data) {
+    // return object untouched
+    if (!data.title) return data
+
+    // remove all exclamation points!!!
+    return Object.assign({}, data, {
+      title: data.title.replace(/!/gm, '')
+    })
+  }
+}
+
+hug(dataDir, options)
+  .on('data', (data) => {
+    console.log(data)
+  })
+```
 
 ## API
 
@@ -147,6 +170,7 @@ becomes
 
 - `dir` String (required) - the full path of the directory to watch
 - `options` Object (optional) - options to pass to the underlying [chokidar](https://github.com/paulmillr/chokidar) file watcher.
+  - `onFileData` Function (optional) - a custom function that can be used to modify datafiles. See [`onFileData` middleware](#onfiledata-middleware).
 
 ## Tests
 

--- a/test/index.js
+++ b/test/index.js
@@ -76,6 +76,26 @@ describe('tree-hugger', function () {
     })
   })
 
+  describe('`onFileData` option for custom data processing', () => {
+    it('allows a custom middleware function', (done) => {
+      const options = {
+        onFileData: function (data) {
+          if (!data || !data.content) return data
+          return Object.assign({}, data, {
+            content: data.content.replace(/WebTorrent/gm, 'PRODUCT_NAME')
+          })
+        }
+      }
+      hug(fixtureDirA, options).on('data', (data) => {
+        expect(data.webtorrent).to.be.an('object')
+        expect(data.webtorrent.data.title).to.be.a('string')
+        expect(data.webtorrent.content).to.include('What is PRODUCT_NAME?')
+        expect(data.webtorrent.content).to.include('see a demo of PRODUCT_NAME')
+        done()
+      })
+    })
+  })
+
   describe('chokidar options', () => {
     it('supports ignored string', (done) => {
       const options = {


### PR DESCRIPTION
This PR adds support for an `onFileData` function that can modify each file's data object after the file is processed and before it gets added to the global data object.

Gonna use this to convert Markdown to HTML on the fly.