### PR TITLE
upgrade to gray-matter 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "chokidar": "^1.7.0",
-    "gray-matter": "^2.1.1",
+    "gray-matter": "^3.0.0",
     "lodash": "^4.17.4",
     "require-yml": "^1.3.1"
   },


### PR DESCRIPTION
Hey @jonschlinkert this PR upgrades gray-matter to version 3 with no other changes and it breaks some of the tests. Is this expected? What were the breaking changes for version 3?